### PR TITLE
Refresh token fix

### DIFF
--- a/backend/app/application.py
+++ b/backend/app/application.py
@@ -1,6 +1,6 @@
 # Import modules and packages
 from fastapi import FastAPI, Request, Depends, HTTPException
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from google_auth_oauthlib.flow import Flow
@@ -203,6 +203,26 @@ async def test_remove_refresh_token(request: Request):
         return {"status": "Refresh token removed"}
     except Exception as e:
         return {"status": "Error", "message": str(e)}
+        
+@app.get("/dump_request")
+async def dump_request(request: Request):
+    """
+    Dumps various attributes of the Request object for debugging.
+    
+    Parameters: request is a FastAPI Request object.
+    Returns: A HTMLResponse of the request dumped.
+    """
+    output = f"Request URL: {request.url}\n"
+    output += f"Request Method: {request.method}\n"
+    output += f"Request Headers:\n"
+    for header, value in request.headers.items():
+        output += f"  {header}: {value}\n"
+    output += f"Request Query Parameters: {request.query_params}\n"
+    output += f"Request Client: {request.client}\n"
+    output += f"Request Cookies: {request.cookies}\n" # Important for checking session
+    output += f"Request State: {request.state}\n"
+
+    return HTMLResponse(f"<pre>{output}</pre>")
 
 @app.get("/drive_data")
 async def drive_data(request: Request, include_trashed: bool = False):

--- a/backend/app/application.py
+++ b/backend/app/application.py
@@ -123,6 +123,20 @@ async def callback(request: Request, code: str, state: str):
     request.session["credentials"] = flow.credentials.to_json()
     return {"status": "authenticated"}
     
+@app.get("/is_authenticated")
+async def is_authenticated(request: Request):
+    """
+    Checks if the user is authenticated.
+
+    Parameters: request is a FastAPI Request object.
+    Returns: a dictionary indicating whether the user is authenticated.
+    """
+    try:
+        credential_handler.get_creds(request.session)
+        return {"status": "authenticated"}  # User is authenticated
+    except HTTPException:
+        return {"status": "not authenticated"}  # User is not authenticated
+    
 @app.get("/test/delete_creds")
 async def test_delete_creds(request: Request):
     """

--- a/backend/app/application.py
+++ b/backend/app/application.py
@@ -55,34 +55,6 @@ app.add_middleware(
 def read_root():
     return {"message": "Hello, Team! Welcome to the Lightcast Consulting Cloud API"}
 
-team_members = [
-    {"id": "1", "item": "Ian King"},
-    {"id": "2", "item": "Shashwot Niraula"},
-    {"id": "3", "item": "Andrew Plum"},
-    {"id": "4", "item": "Bibek Sharma"},
-    {"id": "5", "item": "Caleb Mouat"}
-]
-
-# ---------- BEGIN EXAMPLE FUNCTIONS ----------
-@app.get("/members", tags=["members"])
-async def get_members() -> dict:
-    return { "data": team_members }
-
-@app.post("/members", tags=["members"])
-async def add_member(member: dict) -> dict:
-    team_members.append(member)
-    return {"data": { "Member added." }}
-
-@app.delete("/members/{id}", tags=["members"])
-async def delete_member(memberID: int) -> dict:
-    for member in team_members:
-        if int(member["id"]) == memberID:
-            team_members.remove(member)
-            return {"data": f"Member with id {memberID} has been removed."}
-    return {"data": f"Member with id {memberID} not found"}
-
-# ---------- END EXAMPLE FUNCTIONS ----------
-
 # Google Drive authentication endpoints
 
 @app.get("/auth/login")

--- a/backend/app/application.py
+++ b/backend/app/application.py
@@ -112,7 +112,8 @@ async def login(request: Request):
     authorization_url, _ = flow.authorization_url(
         access_type = 'offline',
         state=state,
-        include_granted_scopes = 'true'
+        include_granted_scopes = 'true',
+        prompt='consent'
     )
     return {"authorization_url": authorization_url}
 


### PR DESCRIPTION
Removed example functions present during the beginning of the project. Added test_expire_token(), test_remove_refresh_token(), test_delete_creds(), dump_request(), exception_auth_redirect(), is_authenticated(), and improved error handling to redirect to /auth/login when refresh token is missing. Mostly ideal, except the application needs to be refreshed twice to bring up login button when refresh token is missing, first to delete the current credentials and next to bring up the button. To change this, the is_authenticated() function should be called by the frontend instead of drive_structure() and the drive_structure() logic should be slightly modified after this.